### PR TITLE
Turn Tiles now updates when a Character dies.

### DIFF
--- a/Online Grid Arena/Assets/Editor/Tests.meta
+++ b/Online Grid Arena/Assets/Editor/Tests.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: fe1107389a9137b44b48b27cc0c2f4db
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 


### PR DESCRIPTION
Bug fix to let turn tiles update again if a character dies.

Closes #39 