### PR TITLE
Make BlackDiceHash class non-static

### DIFF
--- a/Online Grid Arena/Assets/Scripts/Globals/BlackDiceHash.cs
+++ b/Online Grid Arena/Assets/Scripts/Globals/BlackDiceHash.cs
@@ -2,7 +2,7 @@
 using System.Security.Cryptography;
 using System.Text;
 
-public static class BlackDiceHash
+public class BlackDiceHash
 {
     public static string Hash(string input)
     {


### PR DESCRIPTION
Locally, static classes work fine, automated build doesn't recognize the static class, so making the class non-static is the simplest fix.