### PR TITLE
Display rounded up integer values of stats

### DIFF
--- a/Online Grid Arena/Assets/Scripts/Character/CharacterController.cs
+++ b/Online Grid Arena/Assets/Scripts/Character/CharacterController.cs
@@ -276,7 +276,7 @@ public class CharacterController : ICharacterController
     public void UpdateHealthBar()
     {
         HealthBar.SetHealthBarRatio(CharacterStats["health"].CurrentValue / CharacterStats["health"].Value);
-        HealthBar.SetHealthText(CharacterStats["health"].CurrentValue.ToString(), CharacterStats["health"].Value.ToString());
+        HealthBar.SetHealthText(Mathf.CeilToInt(CharacterStats["health"].CurrentValue).ToString(), Mathf.CeilToInt(CharacterStats["health"].Value).ToString());
     }
 
     private void CheckExhausted()

--- a/Online Grid Arena/Assets/Scripts/HUD/StatPanelController.cs
+++ b/Online Grid Arena/Assets/Scripts/HUD/StatPanelController.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using UnityEngine;
+using System.Collections.Generic;
 
 public sealed class StatPanelController : IStatPanelController
 {
@@ -8,16 +9,16 @@ public sealed class StatPanelController : IStatPanelController
     
     public void UpdateStatValues()
     {
-        StatDisplays[0].SetCurrentValueText(CharacterStats["health"].CurrentValue.ToString());
-        StatDisplays[0].SetMaxValueText(CharacterStats["health"].Value.ToString());
+        StatDisplays[0].SetCurrentValueText(Mathf.CeilToInt(CharacterStats["health"].CurrentValue).ToString());
+        StatDisplays[0].SetMaxValueText(Mathf.CeilToInt(CharacterStats["health"].Value).ToString());
 
-        StatDisplays[1].SetCurrentValueText(CharacterStats["moves"].CurrentValue.ToString());
-        StatDisplays[1].SetMaxValueText(CharacterStats["moves"].Value.ToString());
+        StatDisplays[1].SetCurrentValueText(Mathf.CeilToInt(CharacterStats["moves"].CurrentValue).ToString());
+        StatDisplays[1].SetMaxValueText(Mathf.CeilToInt(CharacterStats["moves"].Value).ToString());
 
-        StatDisplays[2].SetCurrentValueText(CharacterStats["attack"].CurrentValue.ToString());
+        StatDisplays[2].SetCurrentValueText(Mathf.CeilToInt(CharacterStats["attack"].CurrentValue).ToString());
         StatDisplays[2].SetMaxValueText("");
 
-        StatDisplays[3].SetCurrentValueText(CharacterStats["defense"].CurrentValue.ToString());
+        StatDisplays[3].SetCurrentValueText(Mathf.CeilToInt(CharacterStats["defense"].CurrentValue).ToString());
         StatDisplays[3].SetMaxValueText("");
     }
 


### PR DESCRIPTION
#168 

## User Story
As a user, I would like my character's stats to not show decimals,

Story Points: 1 
Priority: Medium  
Risk: Low

## Task Breakdown

- [x] Round up stat values in stat panel (15m)
- [x] Round up stat values in health bars (15m)