### PR TITLE
Fix for Pengwin R not executing sometimes

### DIFF
--- a/Online Grid Arena/Assets/Scripts/Abilities/ConcreteAbilities/ArcticFury.cs
+++ b/Online Grid Arena/Assets/Scripts/Abilities/ConcreteAbilities/ArcticFury.cs
@@ -22,6 +22,7 @@ public sealed class ArcticFury : AbstractTargetedAbility, IEventSubscriber
     public void Handle(IEvent @event)
     {
         var type = @event.GetType();
+        // This happens every time someone dies and only gets set to false on Pengwin's turn...
         if (type == typeof(DeathEvent))
         {
             hasSomeoneDied = true;
@@ -30,6 +31,8 @@ public sealed class ArcticFury : AbstractTargetedAbility, IEventSubscriber
 
     protected async override void PrimaryAction(List<IHexTileController> targetTiles)
     {
+        hasSomeoneDied = false;
+
         var isPengwinsTurn = true;
         var enemy = targetTiles[0].OccupantCharacter;
         var enemyQ = targetTiles[0].OccupantCharacter.Abilities[0];
@@ -53,7 +56,6 @@ public sealed class ArcticFury : AbstractTargetedAbility, IEventSubscriber
             else
             {
                 Debug.Log("Duel terminated as a character has died.");
-                hasSomeoneDied = false;
                 break;
             }
         }


### PR DESCRIPTION
Many users reported they were unable to use Pengwin's R sometimes (ability would go on cooldown, nothing would happen). 

Through logging statements, it was shown to be a very simple fix. We were setting a boolean value every time a character would die which would terminate Pengwin's R. It would only get reset during Pengwin's R, rather than before. This meant that any time a character died outside of Pengwin's R, the next time Pengwin tried using his R, it would automatically assume a character died during the ability and would terminate it.

This boolean now gets reset prior to the ability being executed so that the ability always starts and will still get interrupted if Pengwin or his target die during the ability.