### PR TITLE
Deselect abilities and movement by pressing buttons a second time #189

### DIFF
--- a/Online Grid Arena/Assets/Scripts/Control/InputManager.cs
+++ b/Online Grid Arena/Assets/Scripts/Control/InputManager.cs
@@ -23,11 +23,6 @@ public sealed class InputManager : MonoBehaviour, IEventSubscriber
             lastInputParameters = inputParameters;
 
             SelectionManager.UpdateSelectionMode(inputParameters);
-
-            if (inputParameters.IsAbilityKeyPressed() && SelectionManager.SelectedCharacterCanUseAbility(inputParameters.GetAbilityNumber()))
-            {
-                EventBus.Publish(new AbilitySelectedEvent(inputParameters.GetAbilityNumber()));
-            }
         }
     }
 
@@ -50,15 +45,6 @@ public sealed class InputManager : MonoBehaviour, IEventSubscriber
         SelectionManager.UpdateSelectionMode(inputParameters);
 
         Debug.Log($"Ability {inputParameters.GetAbilityNumber()} clicked on Ability Panel.");
-
-        if (inputParameters.IsAbilityKeyPressed() && SelectionManager.SelectedCharacterCanUseAbility(inputParameters.GetAbilityNumber()))
-        {
-            EventBus.Publish(new AbilitySelectedEvent(inputParameters.GetAbilityNumber()));
-        }
-        else
-        {
-            Debug.LogWarning("Ability cannot be used. (Passive or character is exhausted)");
-        }
     }
 
     private IInputParameters GetInputParameters()

--- a/Online Grid Arena/Assets/Scripts/HUD/AbilityPanel.cs
+++ b/Online Grid Arena/Assets/Scripts/HUD/AbilityPanel.cs
@@ -28,7 +28,7 @@ public class AbilityPanel : HideableUI, IAbilityPanel
 
     public void SetAbilityColorUsed(int abilityIndex)
     {
-        AbilityButtons[abilityIndex].GetComponentsInChildren<Image>()[0].color = Color.grey;
+        AbilityButtons[abilityIndex].GetComponentsInChildren<Image>()[0].color = new Color(0.65f, 0.8f, 0.65f, 1.0f);
     }
 
     public void SetAbilityColorDefaultToAll()

--- a/Online Grid Arena/Assets/Scripts/Selection/FreeSelectionController.cs
+++ b/Online Grid Arena/Assets/Scripts/Selection/FreeSelectionController.cs
@@ -9,6 +9,7 @@ public sealed class FreeSelectionController : AbstractSelectionController
     protected override void DoFirst()
     {
         gridSelectionController.BlurAll();
+        gridSelectionController.DehighlightAll();
     }
 
     protected override void DoClickDisabledTile()


### PR DESCRIPTION
#189 

## User Story
As a user, I would like an intuitive way to deselect abilities

From: yoyo_loves_penguins@yoyo.com

Message: 

**1) Clicking an ability while it's selected should deselect it (both with the mouse and the corresponding letter key).** 2) It would be cool if Rocket Cat's Blast Off sets a tree on fire if it's in the AOE.

Story Points: 3 
Priority: medium  
Risk: low

## Task Breakdown

- [x] Toggle ability selection on ability button event (3 hr)
- [x] Toggle movement on movement button event (2 hrs)